### PR TITLE
修复 pnpm dev 报错

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,6 @@
   },
   "dependencies": {
     "vitepress": "2.0.0-alpha.5"
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
之前配置文件报错：

```
remeamiku@RemeaMiku-TB16P:~/repos/WHUDAYS$ pnpm dev

> whudays-doc@1.0.0 dev /home/remeamiku/repos/WHUDAYS
> vitepress dev docs

failed to load config from /home/remeamiku/repos/WHUDAYS/docs/.vitepress/config.js
failed to start server. error:
require() of ES Module /home/remeamiku/repos/WHUDAYS/node_modules/.pnpm/vitepress@2.0.0-alpha.5_@algolia+client-search@5.25.0_less@4.3.0_postcss@8.5.6_search-insights@2.17.3/node_modules/vitepress/dist/node/index.js from /home/remeamiku/repos/WHUDAYS/docs/.vitepress/config.js not supported.
Instead change the require of index.js in /home/remeamiku/repos/WHUDAYS/docs/.vitepress/config.js to a dynamic import() which is available in all CommonJS modules.
Error [ERR_REQUIRE_ESM]: require() of ES Module /home/remeamiku/repos/WHUDAYS/node_modules/.pnpm/vitepress@2.0.0-alpha.5_@algolia+client-search@5.25.0_less@4.3.0_postcss@8.5.6_search-insights@2.17.3/node_modules/vitepress/dist/node/index.js from /home/remeamiku/repos/WHUDAYS/docs/.vitepress/config.js not supported.
Instead change the require of index.js in /home/remeamiku/repos/WHUDAYS/docs/.vitepress/config.js to a dynamic import() which is available in all CommonJS modules.
    at _require.extensions.<computed> [as .js] (file:///home/remeamiku/repos/WHUDAYS/node_modules/.pnpm/vite@6.3.5_less@4.3.0/node_modules/vite/dist/node/chunks/dep-DBxKXgDP.js:49430:9)
    at Object.<anonymous> (/home/remeamiku/repos/WHUDAYS/docs/.vitepress/config.js:25:24)
    at _require.extensions.<computed> [as .js] (file:///home/remeamiku/repos/WHUDAYS/node_modules/.pnpm/vite@6.3.5_less@4.3.0/node_modules/vite/dist/node/chunks/dep-DBxKXgDP.js:49428:16)
    at loadConfigFromBundledFile (file:///home/remeamiku/repos/WHUDAYS/node_modules/.pnpm/vite@6.3.5_less@4.3.0/node_modules/vite/dist/node/chunks/dep-DBxKXgDP.js:49434:17)
    at async bundleAndLoadConfigFile (file:///home/remeamiku/repos/WHUDAYS/node_modules/.pnpm/vite@6.3.5_less@4.3.0/node_modules/vite/dist/node/chunks/dep-DBxKXgDP.js:49259:22)
    at async loadConfigFromFile (file:///home/remeamiku/repos/WHUDAYS/node_modules/.pnpm/vite@6.3.5_less@4.3.0/node_modules/vite/dist/node/chunks/dep-DBxKXgDP.js:49222:44)
    at async resolveUserConfig (file:///home/remeamiku/repos/WHUDAYS/node_modules/.pnpm/vitepress@2.0.0-alpha.5_@algolia+client-search@5.25.0_less@4.3.0_postcss@8.5.6_search-insights@2.17.3/node_modules/vitepress/dist/node/chunk-CJIxUApD.js:17912:27)
    at async resolveConfig (file:///home/remeamiku/repos/WHUDAYS/node_modules/.pnpm/vitepress@2.0.0-alpha.5_@algolia+client-search@5.25.0_less@4.3.0_postcss@8.5.6_search-insights@2.17.3/node_modules/vitepress/dist/node/chunk-CJIxUApD.js:17800:48)
    at async createServer (file:///home/remeamiku/repos/WHUDAYS/node_modules/.pnpm/vitepress@2.0.0-alpha.5_@algolia+client-search@5.25.0_less@4.3.0_postcss@8.5.6_search-insights@2.17.3/node_modules/vitepress/dist/node/chunk-CJIxUApD.js:49627:18)
    at async createDevServer (file:///home/remeamiku/repos/WHUDAYS/node_modules/.pnpm/vitepress@2.0.0-alpha.5_@algolia+client-search@5.25.0_less@4.3.0_postcss@8.5.6_search-insights@2.17.3/node_modules/vitepress/dist/node/cli.js:426:20)
 ELIFECYCLE  Command failed with exit code 1.
```

参考链接：

- https://stackoverflow.com/questions/70541068/instead-change-the-require-of-index-js-to-a-dynamic-import-which-is-available
- https://vite.dev/guide/troubleshooting