### PR TITLE
修复 GitHub Action 的 Build Blog Project 报错

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitepress'
 import {
 	GitChangelog,
 	GitChangelogMarkdownSection,


### PR DESCRIPTION
AI告诉我的，现在应该可以了（大概），自己的仓库Action跑通了

<img width="573" height="966" alt="image" src="https://github.com/user-attachments/assets/c6c01c12-dd74-4052-99f2-b2a5c55bcab3" />
